### PR TITLE
add `Range` method on stored data

### DIFF
--- a/Cache.go
+++ b/Cache.go
@@ -52,6 +52,23 @@ func New(cleaningInterval time.Duration) *Cache {
 	return cache
 }
 
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot of the Map's
+// contents: no key will be visited more than once, but if the value for any key
+// is stored or deleted concurrently, Range may reflect any mapping for that key
+// from any point during the Range call.
+//
+// Range may be O(N) with the number of elements in the map even if f returns
+// false after a constant number of calls.
+func (cache *Cache) Range(f func(key, value interface{}) bool) {
+	fn := func(key, value interface{}) bool {
+		return f(key, value.(item).data)
+	}
+	cache.items.Range(fn)
+}
+
 // Get gets the value for the given key.
 func (cache *Cache) Get(key interface{}) (interface{}, bool) {
 	obj, exists := cache.items.Load(key)

--- a/Cache_test.go
+++ b/Cache_test.go
@@ -59,6 +59,24 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestRange(t *testing.T) {
+	c := cache.New(5 * time.Minute)
+	type user struct {
+		Name string
+	}
+	u := user{
+		Name: "Jon Doe",
+	}
+	c.Set("Hello", &u, time.Hour)
+	c.Range(func(key, value interface{}) bool {
+		value.(*user).Name = "Jane Doe"
+		return true
+	})
+	if u.Name != "Jane Doe" {
+		t.FailNow()
+	}
+}
+
 func BenchmarkNew(b *testing.B) {
 	b.ReportAllocs()
 


### PR DESCRIPTION
I had a use case that I needed the `Range` method on the stored data. So I added it and thought you might want to add it to your repository too.