### PR TITLE
Avoid evicting items that should never expire

### DIFF
--- a/Cache.go
+++ b/Cache.go
@@ -36,7 +36,7 @@ func New(cleaningInterval time.Duration) *Cache {
 				cache.items.Range(func(key, value interface{}) bool {
 					item := value.(item)
 
-					if item.expires < now {
+					if item.expires > 0 && item.expires < now {
 						cache.items.Delete(key)
 					}
 

--- a/Cache_test.go
+++ b/Cache_test.go
@@ -12,6 +12,7 @@ func TestGetSet(t *testing.T) {
 	c := cache.New(cycle)
 	defer c.Close()
 
+	c.Set("sticky", "forever", 0)
 	c.Set("hello", "Hello", cycle/2)
 	hello, found := c.Get("hello")
 
@@ -36,6 +37,11 @@ func TestGetSet(t *testing.T) {
 	_, found = c.Get("404")
 
 	if found {
+		t.FailNow()
+	}
+	
+	_, found = c.Get("sticky")
+	if !found {
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
Bug: items set with a duration value of `0` are not meant to be evicted during cleanup phase. This is not the case currently.

Done: Added checks to guard against this edge case and added test for it
